### PR TITLE
Formatting Changes

### DIFF
--- a/response.tmpl
+++ b/response.tmpl
@@ -16,7 +16,11 @@
 
 {{define "killbody"}}
 *Total Value:* {{.TotalValue}} ISK
-*Pilots Involved ({{len .Killmail.Attackers}}):* _*{{range $attacker := index .FinalBlowPilot}}{{$attacker}}{{end}}*_, {{range $attacker := index .PilotInvolved}}{{$attacker}},{{end}}
-*Corporations Involved ({{len .CorpsInvolved}}):* {{range $corp := index .CorpsInvolved}}{{$corp}}, {{end}}
-*Alliances Involved ({{len .AlliInvolved}}):* {{range $alli := index .AlliInvolved}}{{$alli}}, {{end}}
+{{if .IsSolo}}*Pilots Involved ({{len .Killmail.Attackers}}):* _*{{range $attacker := index .FinalBlowPilot}}{{$attacker}}{{end}}*_
+*Corporations Involved ({{len .TotalCorp}}):* _*{{range $corp := index .FinalBlowCorp}}{{$corp}}{{end}}*_
+*Alliances Involved ({{len .TotalAlli}}):* _*{{range $alli := index .FinalBlowAlli}}{{$alli}}{{end}}*_
+{{else}}*Pilots Involved ({{len .Killmail.Attackers}}):* _*{{range $attacker := index .FinalBlowPilot}}{{$attacker}}{{end}}*_ {{range $attacker := index .PilotInvolved}}, {{$attacker}} {{end}}
+*Corporations Involved ({{len .TotalCorp}}):* _*{{range $corp := index .FinalBlowCorp}}{{$corp}}{{end}}*_ {{range $corp := index .CorpsInvolved}}, {{$corp}} {{end}}
+*Alliances Involved ({{len .TotalAlli}}):* _*{{range $alli := index .FinalBlowAlli}}{{$alli}}{{end}}*_ {{range $alli := index .AlliInvolved}}, {{$alli}} {{end}}
+	{{end}}
 {{end}}

--- a/response.tmpl
+++ b/response.tmpl
@@ -16,7 +16,7 @@
 
 {{define "killbody"}}
 *Total Value:* {{.TotalValue}} ISK
-*Pilots Involved: ({{len .Killmail.Attackers}})* {{range $attacker := index .PilotInvolved}}{{$pilot}}{{end}}
+*Pilots Involved: ({{len .Killmail.Attackers}}) {{range $attacker := index .FinalBlowPilot}}{{$fPilot}}*, {{range $attacker := index .PilotInvolved}}{{$pilot}},{{end}}
 *Corporations Involved: ({{len .CorpsInvolved}})* {{range $corp := index .CorpsInvolved}}{{$corp}}, {{end}}
 *Alliances Involved: ({{len .AlliInvolved}})* {{range $alli := index .AlliInvolved}}{{$alli}}, {{end}}
 {{end}}

--- a/response.tmpl
+++ b/response.tmpl
@@ -16,7 +16,7 @@
 
 {{define "killbody"}}
 *Total Value:* {{.TotalValue}} ISK
-*Pilots Involved: ({{len .Killmail.Attackers}}) {{range $attacker := index .FinalBlowPilot}}{{$fPilot}}*, {{range $attacker := index .PilotInvolved}}{{$pilot}},{{end}}
-*Corporations Involved: ({{len .CorpsInvolved}})* {{range $corp := index .CorpsInvolved}}{{$corp}}, {{end}}
-*Alliances Involved: ({{len .AlliInvolved}})* {{range $alli := index .AlliInvolved}}{{$alli}}, {{end}}
+*Pilots Involved ({{len .Killmail.Attackers}}):* _*{{range $attacker := index .FinalBlowPilot}}{{$attacker}}{{end}}*_, {{range $attacker := index .PilotInvolved}}{{$attacker}},{{end}}
+*Corporations Involved ({{len .CorpsInvolved}}):* {{range $corp := index .CorpsInvolved}}{{$corp}}, {{end}}
+*Alliances Involved ({{len .AlliInvolved}}):* {{range $alli := index .AlliInvolved}}{{$alli}}, {{end}}
 {{end}}

--- a/response.tmpl
+++ b/response.tmpl
@@ -16,13 +16,7 @@
 
 {{define "killbody"}}
 *Total Value:* {{.TotalValue}} ISK
-*Pilots Involved: ({{len .Killmail.Attackers}})* 
-	{{range $attacker := index .Killmail.Attackers}}
-		if {{$attacker.finalBlow}} == 1
-			{{$attacker.Character.Name}}, 
-		else
-			*{{$attacker.Character.Name}}*,
-		{{end}}
+*Pilots Involved: ({{len .Killmail.Attackers}})* {{range $attacker := index .PilotInvolved}}{{$pilot}}{{end}}
 *Corporations Involved: ({{len .CorpsInvolved}})* {{range $corp := index .CorpsInvolved}}{{$corp}}, {{end}}
 *Alliances Involved: ({{len .AlliInvolved}})* {{range $alli := index .AlliInvolved}}{{$alli}}, {{end}}
 {{end}}

--- a/response.tmpl
+++ b/response.tmpl
@@ -15,6 +15,14 @@
 {{end}}
 
 {{define "killbody"}}
-*_Total Value:_ {{.TotalValue}} ISK*
-*_Number Involved:_ {{len .Killmail.Attackers}}*
+*Total Value:* {{.TotalValue}} ISK
+*Pilots Involved: ({{len .Killmail.Attackers}})* 
+	{{range $attacker := index .Killmail.Attackers}}
+		if {{$attacker.finalBlow}} == 1
+			{{$attacker.Character.Name}}, 
+		else
+			*{{$attacker.Character.Name}}*,
+		{{end}}
+*Corporations Involved: ({{len .CorpsInvolved}})* {{range $corp := index .CorpsInvolved}}{{$corp}}, {{end}}
+*Alliances Involved: ({{len .AlliInvolved}})* {{range $alli := index .AlliInvolved}}{{$alli}}, {{end}}
 {{end}}

--- a/slack.go
+++ b/slack.go
@@ -85,6 +85,7 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 			}
 		}
 	}
+	//Compile the list for the final blow pilot
 	for a:= range kill.Killmail.Attackers {
 		if kill.Killmail.attacker.final==0 {
 			okToAdd :=true

--- a/slack.go
+++ b/slack.go
@@ -31,6 +31,10 @@ type data struct {
 	AlliInvolved  []string
 	PilotInvolved []string
 	FinalBlowPilot []string
+	FinalBlowCorp  []string
+	FinalBlowAlli  []string
+	TotalCorp	   []string
+	TotalAlli      []string
 }
 
 // PostKill applys the filter(s) to the kill, and posts the kill to slack
@@ -70,16 +74,20 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 		if kill.Killmail.Attackers[a].FinalBlow == false {
 			okToAdd := true
 			if okToAdd {
-				d.PilotInvolved= append(d.PilotInvolved, kill.Killmail.Attackers[a].Character.Name)
+				d.PilotInvolved = append(d.PilotInvolved, kill.Killmail.Attackers[a].Character.Name)
 			}
 		}
 	}
-	//Compile the list for the final blow pilot
+	//Compile the list for the final blow pilot, mainly use for formatting commas on the post
 	for a := range kill.Killmail.Attackers {
 		if kill.Killmail.Attackers[a].FinalBlow == true {
 			okToAdd :=true
 			if okToAdd {
-				d.FinalBlowPilot= append(d.FinalBlowPilot, kill.Killmail.Attackers[a].Character.Name)
+				d.FinalBlowPilot = append(d.FinalBlowPilot, kill.Killmail.Attackers[a].Character.Name)
+				d.FinalBlowCorp = append(d.FinalBlowCorp, kill.Killmail.Attackers[a].Corporation.Name)
+				d.FinalBlowAlli = append(d.FinalBlowAlli, kill.Killmail.Attackers[a].Alliance.Name)
+				d.TotalCorp = append(d.TotalCorp, kill.Killmail.Attackers[a].Corporation.Name)
+				d.TotalAlli = append(d.TotalAlli, kill.Killmail.Attackers[a].Alliance.Name)
 			}
 			
 		}
@@ -92,9 +100,14 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 				okToAdd = false
 				break
 			}
-		}
-		if okToAdd {
-			d.CorpsInvolved = append(d.CorpsInvolved, kill.Killmail.Attackers[a].Corporation.Name)
+			if kill.Killmail.Attackers[a].Corporation.Name == d.FinalBlowCorp[c] {
+				okToAdd = false
+				break
+			}
+			if okToAdd {
+				d.CorpsInvolved = append(d.CorpsInvolved, kill.Killmail.Attackers[a].Corporation.Name)
+				d.TotalCorp = append(d.TotalCorp, kill.Killmail.Attackers[a].Corporation.Name)
+			}
 		}
 	}
 
@@ -103,7 +116,7 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 		okToAdd := true
 		for c := range d.AlliInvolved {
 			// Do not add blank alliances (corp is not in an alliance)
-			if kill.Killmail.Attackers[a].Alliance.Name == " ," {
+			if kill.Killmail.Attackers[a].Alliance.Name == " " {
 				okToAdd = false
 				break
 			}
@@ -111,9 +124,14 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 				okToAdd = false
 				break
 			}
-		}
-		if okToAdd {
-			d.AlliInvolved = append(d.AlliInvolved, kill.Killmail.Attackers[a].Alliance.Name)
+			if kill.Killmail.Attackers[a].Alliance.Name == d.FinalBlowAlli[c] {
+				okToAdd = false
+				break
+			}
+			if okToAdd {
+				d.AlliInvolved = append(d.AlliInvolved, kill.Killmail.Attackers[a].Alliance.Name)
+				d.TotalAlli = append(d.TotalAlli, kill.Killmail.Attackers[a].Alliance.Name)
+			}
 		}
 	}
 

--- a/slack.go
+++ b/slack.go
@@ -81,7 +81,7 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 		okToAdd := true
 		for c := range d.AlliInvolved {
 			// Do not add blank alliances (corp is not in an alliance)
-			if kill.Killmail.Attackers[a].Alliance.Name == "" {
+			if kill.Killmail.Attackers[a].Alliance.Name == " ,"||","||" " {
 				okToAdd = false
 				break
 			}

--- a/slack.go
+++ b/slack.go
@@ -66,10 +66,10 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 	// Compile list of pilots involved, with special text formatting
 	for a := range kill.Killmail.Attackers {
 		//Special Formatting
-		if {{$attacker.finalBlow}} == 1
-			{{$attacker.Character.Name}}, //Regular Attacker
+		if {{kill.Killmail.attacker.finalBlow}} == 1
+			{{kill.Killmail.attacker.Character.Name}}, //Regular Attacker
 		else
-			*{{$attacker.Character.Name}}*, //Final Blow
+			*{{kill.Killmail.attacker.Character.Name}}*, //Final Blow
 		{{end}}
 		//End Special formatting
 		okToAdd := true

--- a/slack.go
+++ b/slack.go
@@ -67,39 +67,17 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 	
 	// Compile list of pilots involved, if not final blow
 	for a := range kill.Killmail.Attackers {
-		if kill.Killmail.attacker.finalBlow==1 {
+		if kill.Killmail.Attackers[a].FinalBlow == false {
 			okToAdd := true
-			for c := range d.PilotInvolved[c] {
-				// Do not add blank pilots
-				if kill.Killmail.Attackers[a].Character.Name == " ,"||","||" " {
-					okToAdd = false
-					break
-				}
-				if kill.Killmail.Attackers[a].Character.Name == d.PilotInvolved[c] {
-					okToAdd = false
-					break
-				}
-			}
 			if okToAdd {
 				d.PilotInvolved= append(d.PilotInvolved, kill.Killmail.Attackers[a].Character.Name)
 			}
 		}
 	}
 	//Compile the list for the final blow pilot
-	for a:= range kill.Killmail.Attackers {
-		if kill.Killmail.attacker.final==0 {
+	for a := range kill.Killmail.Attackers {
+		if kill.Killmail.Attackers[a].FinalBlow == true {
 			okToAdd :=true
-			for c := range d.FinalBlowPilot[c] {
-				// Do not add blank pilots
-				if kill.Killmail.Attackers[a].Character.Name == " ,"||","||" " {
-					okToAdd = false
-					break
-				}
-				if kill.Killmail.Attackers[a].Character.Name == d.FinalBlowPilot[c] {
-					okToAdd = false
-					break
-				}
-			}
 			if okToAdd {
 				d.FinalBlowPilot= append(d.FinalBlowPilot, kill.Killmail.Attackers[a].Character.Name)
 			}
@@ -125,7 +103,7 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 		okToAdd := true
 		for c := range d.AlliInvolved {
 			// Do not add blank alliances (corp is not in an alliance)
-			if kill.Killmail.Attackers[a].Alliance.Name == " ,"||","||" " {
+			if kill.Killmail.Attackers[a].Alliance.Name == " ," {
 				okToAdd = false
 				break
 			}

--- a/slack.go
+++ b/slack.go
@@ -29,6 +29,8 @@ type data struct {
 	IsSolo        bool
 	CorpsInvolved []string
 	AlliInvolved  []string
+	PilotInvolved []string
+	FinalBlowPilot []string
 }
 
 // PostKill applys the filter(s) to the kill, and posts the kill to slack
@@ -63,32 +65,46 @@ func format(kill *zkill.Kill, channel util.Channel) (messageParams slack.PostMes
 		d.IsLoss = false
 	}
 	
-	// Compile list of pilots involved, with special text formatting
+	// Compile list of pilots involved, if not final blow
 	for a := range kill.Killmail.Attackers {
-		//Special Formatting
-		if {{kill.Killmail.attacker.finalBlow}} == 1
-			{{kill.Killmail.attacker.Character.Name}}, //Regular Attacker
-		else
-			*{{kill.Killmail.attacker.Character.Name}}*, //Final Blow
-		{{end}}
-		//End Special formatting
-		okToAdd := true
-		for c := range d.PilotInvolved[c] {
-			// Do not add blank pilots
-			if kill.Killmail.Attackers[a].Character.Name == " ,"||","||" " {
-				okToAdd = false
-				break
+		if kill.Killmail.attacker.finalBlow==1 {
+			okToAdd := true
+			for c := range d.PilotInvolved[c] {
+				// Do not add blank pilots
+				if kill.Killmail.Attackers[a].Character.Name == " ,"||","||" " {
+					okToAdd = false
+					break
+				}
+				if kill.Killmail.Attackers[a].Character.Name == d.PilotInvolved[c] {
+					okToAdd = false
+					break
+				}
 			}
-			if kill.Killmail.Attackers[a].Character.Name == d.PilotInvolved[c] {
-				okToAdd = false
-				break
+			if okToAdd {
+				d.PilotInvolved= append(d.PilotInvolved, kill.Killmail.Attackers[a].Character.Name)
 			}
-		}
-		if okToAdd {
-			d.PilotInvolved= append(d.PilotInvolved, kill.Killmail.Attackers[a].Character.Name)
 		}
 	}
-	
+	for a:= range kill.Killmail.Attackers {
+		if kill.Killmail.attacker.final==0 {
+			okToAdd :=true
+			for c := range d.FinalBlowPilot[c] {
+				// Do not add blank pilots
+				if kill.Killmail.Attackers[a].Character.Name == " ,"||","||" " {
+					okToAdd = false
+					break
+				}
+				if kill.Killmail.Attackers[a].Character.Name == d.FinalBlowPilot[c] {
+					okToAdd = false
+					break
+				}
+			}
+			if okToAdd {
+				d.FinalBlowPilot= append(d.FinalBlowPilot, kill.Killmail.Attackers[a].Character.Name)
+			}
+			
+		}
+	}
 	// Compile list of corporations involved from attackers, ignoring duplicates
 	for a := range kill.Killmail.Attackers {
 		okToAdd := true


### PR DESCRIPTION
Italicized/Bolded Pilot/Corp/Alliance with final blow

Added functionality for other users to tweak templates for their liking instead of modifying the code
- Total Corp/Alli now lists all corps or alliances involved in the fight
- Corps/Alli/Pilot Involved lists all of the named group that _DOESN'T_ contain the pilot with the killmail
- FinalBlowPilot/Corp/Alli lists the named group that contains the pilot with the killmail

Tested locally
